### PR TITLE
[openshift] expose management port via Service

### DIFF
--- a/openshift/template.yml
+++ b/openshift/template.yml
@@ -130,6 +130,10 @@ objects:
       port: 80
       protocol: TCP
       targetPort: proxy
+    - name: management
+      protocol: TCP
+      port: 8090
+      targetPort: management
     selector:
       deploymentconfig: apicast
 


### PR DESCRIPTION
To expose policies endpoint from the management API via route we need to create a Service first.