### PR TITLE
Add production env file needed by Test::APIcast

### DIFF
--- a/apicast/gateway/config/production.lua
+++ b/apicast/gateway/config/production.lua
@@ -1,0 +1,6 @@
+-- This is needed for the integration tests. They assume that there is a
+-- 'production' environment available in apicast/gateway/config/.
+-- This file is not included in the image built using the templates in
+-- /openshift.
+
+return { }

--- a/openshift/06-apicast-cloud-hosted-build-config-policy-disabler.yml
+++ b/openshift/06-apicast-cloud-hosted-build-config-policy-disabler.yml
@@ -24,7 +24,11 @@ spec:
 
       USER root
 
-      RUN rm -f src/apicast/policy/{rate_limit,token_introspection,3scale_batcher,conditional,logging}/apicast-policy.json
+      # 'src/gateway' contains files needed to pass the integration tests, but
+      # those are not needed in the image.
+      # We also delete the schemas of the policies that we want to disable.
+      RUN rm -f src/gateway \
+          src/apicast/policy/{rate_limit,token_introspection,3scale_batcher,conditional,logging}/apicast-policy.json
 
       USER 1001
 


### PR DESCRIPTION
Closes #13 

The file is needed to pass the integration tests, but it does not need to be included in the built image.