### PR TITLE
Argparse: Bump version to 0.6.0-1

### DIFF
--- a/apicast/Roverfile.lock
+++ b/apicast/Roverfile.lock
@@ -1,5 +1,5 @@
 apicast scm-1|b5d23fff7c8f5ecdcab34e74ce9a51171d125115|development,test
-argparse 0.5.0-1||development,test
+argparse 0.6.0-1||development,test
 inspect 3.1.1-0||development,test
 liquid 0.1.3-1||development,test
 ljsonschema 0.1.0-1||development,test


### PR DESCRIPTION
Due to the change in lua-rover to skip `all` arch in lua_modules, the
argparse dependency fails due to invalid copy command in the 0.5 version.

This commit bump argparse version to 0.6.0-1

Relate to: https://github.com/3scale/lua-rover/commit/ec9fa0b66cfb89936e0650969178407409a4750b

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>