### PR TITLE
Use the specific release tag for the mapping-service, not master

### DIFF
--- a/openshift/04-deployment-template.yml
+++ b/openshift/04-deployment-template.yml
@@ -21,7 +21,7 @@ objects:
       spec:
         containers:
         - name: apicast-mapping-service
-          image: "${MAPPING_SERVICE_IMAGE}"
+          image: quay.io/3scale/apicast-cloud-hosted:mapping-service-${RELEASE_REF}
           imagePullPolicy: Always
           env:
           - name: MASTER_ACCESS_TOKEN
@@ -195,11 +195,6 @@ parameters:
 - description: "Cache TTL in seconds. For how long cache configurations"
   name: CACHE_TTL
   required: true
-
-- name: MAPPING_SERVICE_IMAGE
-  description: "Mapping Service image name. Used to discover proxy configurations."
-  required: true
-  value: "quay.io/3scale/apicast-cloud-hosted:mapping-service-master"
 
 - name: MASTER_ACCESS_TOKEN_SECRET
   description: "Secret name that containts System Master Access Token password"


### PR DESCRIPTION
The deployment template sets the mapping-service image to "quay.io/3scale/apicast-cloud-hosted:mapping-service-master" by default when `MAPPING_SERVICE_IMAGE` envvar is unset. As using master in production is not desirable, this PR makes the template use the "RELEASE_REF" envvar to get a fixed tag that corresponds with the current apicast-cloud-hosted release.

This change is required to allow the generation of new apicast-cloud-hosted images for the new staging environment without the risk of accidentally deploying something broken to current production.