### PR TITLE
docs: add missing step to apicast-cloud-hosted procedure

### DIFF
--- a/openshift/README.md
+++ b/openshift/README.md
@@ -44,6 +44,8 @@
     $ make deploy RELEASE_REF=v3-5-0-beta1 ENVIRONMENT=staging CACHE_TTL=30
 ```
 
+* Manually update the `apicast-mapping-service` DeploymentConfig image to use the dot notation `quay.io/3scale/apicast-cloud-hosted:mapping-service-v3.5.0-beta1` as the image is generated in the CI and fetched directly from `quay.io`.
+
 * Update both Routes pointing to new services version `v3-5-0-beta1` with weight 0 by the moment (leaving old but productive version `v3-4-0` with weight 100).
 
 ## Apicast-production canary preparation
@@ -68,6 +70,8 @@
     $ oc project apicast-production
     $ make deploy RELEASE_REF=v3-5-0-beta1 ENVIRONMENT=production CACHE_TTL=300
 ```
+
+* Manually update the `apicast-mapping-service` DeploymentConfig image to use the dot notation `quay.io/3scale/apicast-cloud-hosted:mapping-service-v3.5.0-beta1` as the image is generated in the CI and fetched directly from `quay.io`.
 
 * Update both Routes pointing to new services version `v3-5-0-beta1` with weight 0 by the moment (leaving old but productive version `v3-4-0` with weight 100).
 


### PR DESCRIPTION
It should be fixed in the makefile / template, but hopefully this procedure will be never be executed again, so a note should be enough.

How often: ideally never.
Shave off: 30 seconds.

![image](https://user-images.githubusercontent.com/795289/115382932-85cf6680-a1d5-11eb-8673-57b557185622.png)
