### PR TITLE
Update base image to 3scale2.13

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-BASE_IMAGE_REPO ?= quay.io/3scale/rh-apicast
-BASE_IMAGE_TAG ?= 3scale2.12
+BASE_IMAGE_REPO ?= quay.io/3scale/apicast-cloud-hosted
+BASE_IMAGE_TAG ?= 3scale2.13-1.22.0-5
 BUILD_INFO ?= 001
 IMAGE_NAME ?= apicast-cloud-hosted
 DOCKER ?= docker


### PR DESCRIPTION
Base image used for both apicast/mapping-service image build have been manually added to  repo `quay.io/3scale/apicast-cloud-hosted:3scale2.13-1.22.0-5` (using productized image):

```
$ docker pull registry-proxy.engineering.redhat.com/rh-osbs/3scale-amp2-apicast-gateway-rhel8:1.22.0-5

$ docker tag registry-proxy.engineering.redhat.com/rh-osbs/3scale-amp2-apicast-gateway-rhel8:1.22.0-5 quay.io/3scale/apicast-cloud-hosted:3scale2.13-1.22.0-5

$ docker push quay.io/3scale/apicast-cloud-hosted:3scale2.13-1.22.0-5
```

I locally checked the:
1. **apicast** image build, test and probe:
```bash
$ cd apicast && make test && make prove
...
docker run --rm -e TEST_NGINX_BINARY=openresty -e TEST_NGINX_SERVROOT=/tmp/servroot apicast-cloud-hosted:apicast-3scale2.13-1.22.0-5-001 prove
nginx: [warn] could not build optimal variables_hash, you should increase either variables_hash_max_size: 1024 or variables_hash_bucket_size: 64; ignoring variables_hash_bucket_size
nginx: [warn] conflicting server name "_" on 0.0.0.0:1984, ignored
TEST 2: balancer upstream blacklist - WARNING: killing the child process 35 with force... at /usr/local/share/perl5/Test/Nginx/Util.pm line 581.
nginx: [warn] could not build optimal variables_hash, you should increase either variables_hash_max_size: 1024 or variables_hash_bucket_size: 64; ignoring variables_hash_bucket_size
nginx: [warn] conflicting server name "_" on 0.0.0.0:1984, ignored
TEST 3: balancer upstream with APIAP config - WARNING: killing the child process 72 with force... at /usr/local/share/perl5/Test/Nginx/Util.pm line 581.
nginx: [warn] could not build optimal variables_hash, you should increase either variables_hash_max_size: 1024 or variables_hash_bucket_size: 64; ignoring variables_hash_bucket_size
nginx: [warn] conflicting server name "_" on 0.0.0.0:1984, ignored
END - WARNING: killing the child process 109 with force... at /usr/local/share/perl5/Test/Nginx/Util.pm line 581.
t/blacklist.t .. ok
All tests successful.
Files=1, Tests=14, 14 wallclock secs ( 0.01 usr  0.00 sys +  3.21 cusr  0.57 csys =  3.79 CPU)
Result: PASS
```
2. **mapping-service** image build, test and probe:
```
$ cd mapping-service && make test && make prove
....
docker run --rm \
	-e TEST_NGINX_BINARY=openresty \
	-e TEST_NGINX_SERVROOT=/tmp/servroot \
	-e TEST_NGINX_CLIENT_PORT=8093 \
	apicast-cloud-hosted:mapping-service-3scale2.13-1.22.0-5-001 prove
t/001-mapping-service.t TEST 2: does not crash without host - timeout when waiting for the process 11 to exit at /usr/local/share/perl5/Test/Nginx/Util.pm line 668.
t/001-mapping-service.t TEST 2: does not crash without host - WARNING: killing the child process 11 with force... at /usr/local/share/perl5/Test/Nginx/Util.pm line 707.
t/001-mapping-service.t TEST 3: does not crash without env - timeout when waiting for the process 14 to exit at /usr/local/share/perl5/Test/Nginx/Util.pm line 668.
t/001-mapping-service.t TEST 3: does not crash without env - WARNING: killing the child process 14 with force... at /usr/local/share/perl5/Test/Nginx/Util.pm line 707.
t/001-mapping-service.t TEST 4: does not crash on services endpoint - timeout when waiting for the process 17 to exit at /usr/local/share/perl5/Test/Nginx/Util.pm line 668.
t/001-mapping-service.t TEST 4: does not crash on services endpoint - WARNING: killing the child process 17 with force... at /usr/local/share/perl5/Test/Nginx/Util.pm line 707.
END - timeout when waiting for the process 20 to exit at /usr/local/share/perl5/Test/Nginx/Util.pm line 668.
END - WARNING: killing the child process 20 with force... at /usr/local/share/perl5/Test/Nginx/Util.pm line 707.
t/001-mapping-service.t .. ok
All tests successful.
Files=1, Tests=18, 27 wallclock secs ( 0.02 usr  0.00 sys +  0.21 cusr  0.06 csys =  0.29 CPU)
Result: PASS
```

3. And **mapping-service** busted (rua test framework):
```
$ cd mapping-service && make busted
...
+2022/12/19 15:59:35 [warn] 9208#9208: *2 [lua] cache_store.lua:350: send(): http cache store: not cacheable response, context: ngx.timer
2022/12/19 15:59:35 [warn] 9208#9208: *2 [lua] cache_store.lua:350: send(): http cache store: not cacheable response, context: ngx.timer
2022/12/19 15:59:35 [error] 9208#9208: *2 [lua] mapping_service.lua:176: provider_domain(): failed to load Provider Domain, context: ngx.timer
+2022/12/19 15:59:35 [warn] 9208#9208: *2 [lua] cache_store.lua:350: send(): http cache store: not cacheable response, context: ngx.timer
+2022/12/19 15:59:35 [warn] 9208#9208: *2 [lua] cache_store.lua:350: send(): http cache store: not cacheable response, context: ngx.timer
2022/12/19 15:59:35 [warn] 9208#9208: *2 [lua] cache_store.lua:350: send(): http cache store: not cacheable response, context: ngx.timer
2022/12/19 15:59:35 [error] 9208#9208: *2 [lua] mapping_service.lua:79: create_sso(): failed to create SSO token: 403, context: ngx.timer
+2022/12/19 15:59:35 [warn] 9208#9208: *2 [lua] cache_store.lua:350: send(): http cache store: not cacheable response, context: ngx.timer
2022/12/19 15:59:35 [warn] 9208#9208: *2 [lua] cache_store.lua:350: send(): http cache store: not cacheable response, context: ngx.timer
2022/12/19 15:59:35 [error] 9208#9208: *2 [lua] mapping_service.lua:140: load_configs(): failed to load Proxy Configs, context: ngx.timer
+
5 successes / 0 failures / 0 errors / 0 pending : 0.013724 seconds
```

And all tests are passing.

Once PR gets merged, GitHub Action will do the real release to repo `quay.io/3scale/apicast-cloud-hosted`