### PR TITLE
Add possiblity to execute release workflow GH action with manual trigger

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,6 +5,8 @@ on:
     branches:
       - master
 
+  workflow_dispatch:
+
 jobs:
   build:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
Last PR https://github.com/3scale/apicast-cloud-hosted/pull/42 did not trigger `release` GH action worflow.

This PR adds the possibility to manually trigger the `release` GH action worflow.

Also, just in case it did not work because merge event to `master` was lost, it will be executed because it will be a merge to `master`.