### PR TITLE
Add busted test to mapping-service release GH action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,7 +30,7 @@ jobs:
         run: cd mapping-service && make build
 
       - name: Test mapping-service image
-        run: cd mapping-service && make test && make prove
+        run: cd mapping-service && make busted && make test && make prove
 
       - name: Export release name
         run: |


### PR DESCRIPTION
The test GH action of mapping-service application, was already executing the `make busted` (lua test framework).

This command has also been added into the release GH action.