### PR TITLE
Update base image to 3scale 2.15.2 (apicast-gateway 1.25.0-35)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 BASE_IMAGE_REPO ?= quay.io/3scale/apicast-cloud-hosted
-BASE_IMAGE_TAG ?= 3scale2.13-1.23.0-12
-BUILD_INFO ?= 002
+BASE_IMAGE_TAG ?= 3scale2.15.2-1.25.0-35
+BUILD_INFO ?= 001
 IMAGE_NAME ?= apicast-cloud-hosted
 DOCKER ?= docker
 REGISTRY ?= quay.io/3scale


### PR DESCRIPTION
## Procedure

## Base image creation

- Check required image tag from https://catalog.redhat.com/software/containers/3scale-amp2/apicast-gateway-rhel8/5df398c85a13466876712703?container-tabs=overview, on that case `3scale-amp2-apicast-gateway-rhel8:1.25.0-35`

- Locally, connect to  **RH VPN** (to be able to get image from private registry `registry-proxy.engineering.redhat.com/rh-osbs/3scale-amp2-apicast-gateway-rhel8`), and push the base image to quay

  - Obtain desired base image from private RH registry
  ```
  docker pull registry-proxy.engineering.redhat.com/rh-osbs/3scale-amp2-apicast-gateway-rhel8:1.25.0-35
  ```
  -  Re-tag base image to quay.io image including 3scale `2.15.2` and apicast `1.25.0-35` versions
  ```
  docker tag registry-proxy.engineering.redhat.com/rh-osbs/3scale-amp2-apicast-gateway-rhel8:1.25.0-35 quay.io/3scale/apicast-cloud-hosted:3scale2.15.2-1.25.0-35
  ```
  - Push base image to quay
  ```
  docker push quay.io/3scale/apicast-cloud-hosted:3scale2.15.2-1.25.0-35
  ```

## 2 Local tests

1. **apicast** image build, test and probe:
```bash
$ cd apicast && make test && make prove
...


t/blacklist.t .. ok
All tests successful.
Files=1, Tests=14, 13 wallclock secs ( 0.01 usr  0.01 sys +  2.43 cusr  0.54 csys =  2.99 CPU)
Result: PASS
```

2. **mapping-service** image build, test and probe:
```bash
$ cd mapping-service && make busted && make test && make prove
...

5 successes / 0 failures / 0 errors / 0 pending : 0.013689 seconds

...

t/001-mapping-service.t .. ok
All tests successful.
Files=1, Tests=18, 27 wallclock secs ( 0.01 usr  0.01 sys +  0.17 cusr  0.08 csys =  0.27 CPU)
Result: PASS
```

And all tests are passing.

Once PR gets merged, GitHub Action will do the real release to repo `quay.io/3scale/apicast-cloud-hosted`
