### PR TITLE
Release 3scale2.15.2-1.25.0-35-002

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 BASE_IMAGE_REPO ?= quay.io/3scale/apicast-cloud-hosted
 BASE_IMAGE_TAG ?= 3scale2.15.2-1.25.0-35
-BUILD_INFO ?= 001
+BUILD_INFO ?= 002
 IMAGE_NAME ?= apicast-cloud-hosted
 DOCKER ?= docker
 REGISTRY ?= quay.io/3scale


### PR DESCRIPTION
Second release of `3scale2.15.2-1.25.0-35` including the mapping-service fix from https://github.com/3scale/apicast-cloud-hosted/pull/50.

Local tests have been tested:
```bash
$ cd apicast && make test && make prove
$ cd mapping-service && make busted && make test && make prove
```

And all tests are passing (initially mapping-service test did not pass on my local machine because I needed to clear the cache).

Once PR gets merged, GitHub Action will do the real release to repo `quay.io/3scale/apicast-cloud-hosted`.