### PR TITLE
Release/3scale2.14.3 (apicast-gateway 1.24.0-94)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 BASE_IMAGE_REPO ?= quay.io/3scale/apicast-cloud-hosted
-BASE_IMAGE_TAG ?= 3scale2.15.2-1.25.0-35
-BUILD_INFO ?= 002
+BASE_IMAGE_TAG ?= 3scale2.14.3-1.24.0-94
+BUILD_INFO ?= 001
 IMAGE_NAME ?= apicast-cloud-hosted
 DOCKER ?= docker
 REGISTRY ?= quay.io/3scale

--- a/mapping-service/Makefile
+++ b/mapping-service/Makefile
@@ -20,7 +20,7 @@ prove: build ## Run mapping-service tests
 		-e TEST_NGINX_CLIENT_PORT=8093 \
 		$(LOCAL_IMAGE_NAME) prove
 
-busted: ## Run lua tests in the $(S2I_OPENRESTY_IMAGE) image
+busted: build ## Run lua tests in the $(S2I_OPENRESTY_IMAGE) image
 	docker run --rm -u $(shell id -u)  \
 		-v ./spec:/opt/app-root/src/spec \
 		-v ./.busted:/opt/app-root/src/.busted \


### PR DESCRIPTION
## Procedure

## Base image creation

- Check required image tag from [https://catalog.redhat.com/software/containers/3scale-amp2/apicast-gateway-rhel8/5df39[…]2703?container-tabs=overview&image=672c3126adf6be9287e9ffeb](https://catalog.redhat.com/software/containers/3scale-amp2/apicast-gateway-rhel8/5df398c85a13466876712703?container-tabs=overview&image=672c3126adf6be9287e9ffeb), on that case `3scale-amp2-apicast-gateway-rhel8:1.24.0-94`

- Locally, connect to  **RH VPN** (to be able to get image from private registry `registry-proxy.engineering.redhat.com/rh-osbs/3scale-amp2-apicast-gateway-rhel8`), and push the base image to quay

  - Obtain desired base image from private RH registry
  ```
  docker pull registry-proxy.engineering.redhat.com/rh-osbs/3scale-amp2-apicast-gateway-rhel8:1.24.0-94
  ```
  -  Re-tag base image to quay.io image including 3scale `2.14.3` and apicast `1.24.0-94` versions
  ```
  docker tag registry-proxy.engineering.redhat.com/rh-osbs/3scale-amp2-apicast-gateway-rhel8:1.24.0-94 quay.io/3scale/apicast-cloud-hosted:3scale2.14.3-1.24.0-94
  ```
  - Push base image to quay
  ```
  docker push quay.io/3scale/apicast-cloud-hosted:3scale2.14.3-1.24.0-94
  ```

## 2 Local tests

1. **apicast** image build, test and probe:
```bash
$ cd apicast && make test && make prove
...


t/blacklist.t .. ok
All tests successful.
Files=1, Tests=14, 14 wallclock secs ( 0.02 usr  0.00 sys +  2.35 cusr  0.57 csys =  2.94 CPU)
Result: PASS
```

2. **mapping-service** image build, test and probe:
```bash
$ cd mapping-service && make busted && make test && make prove
...

5 successes / 0 failures / 0 errors / 0 pending : 0.006649 seconds

...

All tests successful.
Files=1, Tests=18, 27 wallclock secs ( 0.02 usr  0.00 sys +  0.16 cusr  0.08 csys =  0.26 CPU)
Result: PASS

```

And all tests are passing.

Once PR gets merged, GitHub Action will do the real release to repo `quay.io/3scale/apicast-cloud-hosted`
