### PR TITLE
Fix release Github workflow by setting latest ubuntu image

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
With latest PR merged https://github.com/3scale/apicast-cloud-hosted/pull/52 the release workflow was cancelled because using a deprecated ubuntu image , since ubuntu 20 has been deprecated today (what a coincidence):

https://github.com/3scale/apicast-cloud-hosted/actions/runs/14470302811